### PR TITLE
Fix code scanning alert no. 9: Clear-text storage of sensitive information

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -100,7 +100,8 @@ class AppFactory:
         if not Path("is_init.txt").exists():
 
             with open("is_init.txt", "w") as f:
-                f.write(f"{init_database(app, db)}")
+                result = init_database(app, db)
+                f.write(result)
 
         from app.models import Users
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -87,7 +87,9 @@ def init_database(app: Flask, db: SQLAlchemy) -> str:
             db.session.add(license_user)
             db.session.commit()
 
-            return f" * Root Pw: {passwd}"
+            import hashlib
+            hashed_passwd = hashlib.sha256(passwd.encode()).hexdigest()
+            return f" * Root Pw (hashed): {hashed_passwd}"
 
     except Exception as e:
         raise e


### PR DESCRIPTION
Fixes [https://github.com/REM-Infotech/CrawJUD-Web/security/code-scanning/9](https://github.com/REM-Infotech/CrawJUD-Web/security/code-scanning/9)

To fix the problem, we should avoid storing the password in clear text. Instead, we can store a hashed version of the password using a secure hashing algorithm. This way, even if the file is compromised, the actual password remains protected.

- Use the `hashlib` library to hash the password before storing it.
- Update the `init_database` function in `app/models/__init__.py` to hash the password.
- Update the `init_database` method in `app/__init__.py` to handle the hashed password appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
